### PR TITLE
Refactor the logic of matching applications

### DIFF
--- a/console/src/composables/use-app-compare.ts
+++ b/console/src/composables/use-app-compare.ts
@@ -1,4 +1,4 @@
-import { AppType } from "@/constant";
+import { AppType, STORE_APP_ID } from "@/constant";
 import type { ApplicationSearchResult } from "@/types";
 import type { Plugin, PluginList, Theme, ThemeList } from "@halo-dev/api-client";
 import { useQuery } from "@tanstack/vue-query";
@@ -24,7 +24,7 @@ export function useAppCompare(app: Ref<ApplicationSearchResult | undefined>) {
   });
 
   const { data: installedThemes } = useQuery<Theme[]>({
-    queryKey: ["themes"],
+    queryKey: ["installed-themes"],
     queryFn: async () => {
       const { data } = await axios.get<ThemeList>("/apis/api.console.halo.run/v1alpha1/themes?uninstalled=false");
       return data.items;
@@ -35,8 +35,7 @@ export function useAppCompare(app: Ref<ApplicationSearchResult | undefined>) {
   const matchedPlugin = computed(() => {
     if (appType.value === AppType.PLUGIN) {
       return installedPlugins.value?.find(
-        // TODO: 后续应用市场服务需要添加 metadata.name 字段，当前使用 displayName 代替
-        (plugin) => plugin.spec.displayName === app.value?.application.spec.displayName
+        (plugin) => plugin.metadata.annotations?.[STORE_APP_ID] === app.value?.application.metadata.name
       );
     }
     return undefined;
@@ -44,8 +43,9 @@ export function useAppCompare(app: Ref<ApplicationSearchResult | undefined>) {
 
   const matchedTheme = computed(() => {
     if (appType.value === AppType.THEME) {
-      // TODO: 后续应用市场服务需要添加 metadata.name 字段，当前使用 displayName 代替
-      return installedThemes.value?.find((theme) => theme.spec.displayName === app.value?.application.spec.displayName);
+      return installedThemes.value?.find(
+        (theme) => theme.metadata.annotations?.[STORE_APP_ID] === app.value?.application.metadata.name
+      );
     }
     return undefined;
   });

--- a/console/src/composables/use-app-control.ts
+++ b/console/src/composables/use-app-control.ts
@@ -6,187 +6,31 @@ import { useMutation, useQueryClient } from "@tanstack/vue-query";
 import type { Plugin, Theme } from "@halo-dev/api-client";
 import storeApiClient from "@/utils/store-api-client";
 import { apiClient } from "@/utils/api-client";
+import { STORE_APP_ID } from "@/constant";
 
 export function useAppControl(app: Ref<ApplicationSearchResult | undefined>) {
-  const queryClient = useQueryClient();
+  const { appType, hasInstalled, isSatisfies } = useAppCompare(app);
 
-  const { appType, matchedPlugin, matchedTheme, hasInstalled, isSatisfies } = useAppCompare(app);
-
-  async function getDownloadUrl() {
-    if (!app.value) {
-      return;
-    }
-
-    const { name: appName } = app.value.application.metadata;
-    const { data: appDetail } = await storeApiClient.get<ApplicationDetail>(
-      `/apis/api.store.halo.run/v1alpha1/applications/${appName}`
-    );
-
-    if (!appDetail.latestRelease?.assets?.length) {
-      return;
-    }
-
-    const { name: releaseName } = appDetail.latestRelease.release.metadata;
-    const { name: assetName } = appDetail.latestRelease.assets[0].metadata;
-
-    return `${
-      import.meta.env.VITE_APP_STORE_BACKEND
-    }/store/apps/${appName}/releases/download/${releaseName}/assets/${assetName}`;
-  }
-
-  const { isLoading: installing, mutate: handleInstall } = useMutation({
-    mutationKey: ["app-installation"],
-    mutationFn: async () => {
-      if (!app.value?.latestRelease) {
-        Toast.error("无法获取最新版本信息");
-        return;
-      }
-
-      const downloadUrl = await getDownloadUrl();
-
-      if (!downloadUrl) {
-        Toast.error("无法获取最新版本信息");
-        return;
-      }
-
+  const { installing, handleInstall, handleUpgrade, upgrading } =
+    (function () {
       if (appType.value === "PLUGIN") {
-        await apiClient.plugin.installPluginFromUri({
-          installFromUriRequest: { uri: downloadUrl },
-        });
-      } else if (appType.value === "THEME") {
-        await apiClient.theme.installThemeFromUri({ installFromUriRequest: { uri: downloadUrl } });
-      } else {
-        Toast.error("未知应用类型");
-        return;
+        return usePluginAppControl(app);
       }
-
-      Toast.success("安装成功");
-
-      queryClient.invalidateQueries({ queryKey: ["plugins"] });
-      queryClient.invalidateQueries({ queryKey: ["themes"] });
-    },
-  });
-
-  const { isLoading: upgrading, mutate: handleUpgrade } = useMutation({
-    mutationKey: ["app-upgrade"],
-    mutationFn: async () => {
-      if (!app.value?.latestRelease) {
-        Toast.error("无法获取最新版本信息");
-        return;
-      }
-
-      const downloadUrl = await getDownloadUrl();
-
-      if (!downloadUrl) {
-        Toast.error("无法获取最新版本信息");
-        return;
-      }
-
-      if (appType.value === "PLUGIN") {
-        if (!matchedPlugin.value) {
-          Toast.error("未找到匹配的插件");
-          return;
-        }
-
-        await apiClient.plugin.upgradePluginFromUri({
-          name: matchedPlugin.value.metadata.name,
-          upgradeFromUriRequest: { uri: downloadUrl },
-        });
-
-        if (await checkPluginUpgradeStatus(matchedPlugin.value, app.value.latestRelease.spec.version)) {
-          Toast.success("升级成功");
-          queryClient.invalidateQueries({ queryKey: ["plugins"] });
-        }
-        return;
-      }
-
       if (appType.value === "THEME") {
-        if (!matchedTheme.value) {
-          Toast.error("未找到匹配的主题");
-          return;
-        }
-
-        await apiClient.theme.upgradeThemeFromUri({
-          name: matchedTheme.value.metadata.name,
-          upgradeFromUriRequest: { uri: downloadUrl },
-        });
-
-        if (await checkThemeUpgradeStatus(matchedTheme.value, app.value.latestRelease.spec.version)) {
-          Toast.success("升级成功");
-          queryClient.invalidateQueries({ queryKey: ["installed-themes"] });
-        }
-        return;
+        return useThemeAppControl(app);
       }
-
-      Toast.error("未知应用类型");
-    },
-  });
-
-  function checkPluginUpgradeStatus(plugin: Plugin, expectVersion?: string) {
-    const maxRetry = 5;
-    let retryCount = 0;
-    return new Promise((resolve, reject) => {
-      const check = () => {
-        if (retryCount >= maxRetry) {
-          reject(false);
-          return;
-        }
-        apiClient.extension.plugin
-          .getpluginHaloRunV1alpha1Plugin({ name: plugin.metadata.name })
-          .then((response) => {
-            const { version } = response.data.spec;
-            if (version === expectVersion) {
-              resolve(true);
-            } else {
-              setTimeout(check, 1000);
-              retryCount++;
-            }
-          })
-          .catch(() => {
-            reject(false);
-          });
-      };
-      check();
-    });
-  }
-
-  function checkThemeUpgradeStatus(theme: Theme, expectVersion?: string) {
-    const maxRetry = 5;
-    let retryCount = 0;
-    return new Promise((resolve, reject) => {
-      const check = () => {
-        if (retryCount >= maxRetry) {
-          reject(false);
-          return;
-        }
-        apiClient.extension.theme
-          .getthemeHaloRunV1alpha1Theme({ name: theme.metadata.name })
-          .then((response) => {
-            const { version } = response.data.spec;
-            if (version === expectVersion) {
-              resolve(true);
-            } else {
-              setTimeout(check, 1000);
-              retryCount++;
-            }
-          })
-          .catch(() => {
-            reject(false);
-          });
-      };
-      check();
-    });
-  }
+      return undefined;
+    })() || {};
 
   const actions = computed(() => {
     return [
       {
-        label: installing.value ? "安装中" : "安装",
+        label: installing?.value ? "安装中" : "安装",
         type: "default",
         available:
           !hasInstalled.value && isSatisfies.value && app.value?.application.spec.priceConfig?.mode !== "ONE_TIME",
         onClick: handleInstall,
-        loading: installing.value,
+        loading: installing?.value,
         disabled: false,
       },
       {
@@ -224,4 +68,268 @@ export function useAppControl(app: Ref<ApplicationSearchResult | undefined>) {
   });
 
   return { installing, upgrading, handleInstall, handleUpgrade, action };
+}
+
+function usePluginAppControl(app: Ref<ApplicationSearchResult | undefined>) {
+  const queryClient = useQueryClient();
+  const { getDownloadUrl } = useAppRelease(app);
+  const { matchedPlugin } = useAppCompare(app);
+
+  const { mutate: handleInstall, isLoading: installing } = useMutation({
+    mutationKey: ["install-plugin"],
+    mutationFn: async () => {
+      const downloadUrl = await getDownloadUrl();
+      if (!downloadUrl) {
+        return;
+      }
+      const { data: plugin } = await apiClient.plugin.installPluginFromUri({
+        installFromUriRequest: { uri: downloadUrl },
+      });
+      return await handleUpdateAnnotations({
+        plugin,
+        additionalAnnotations: {
+          [STORE_APP_ID]: app.value?.application.metadata.name || "",
+        },
+      });
+    },
+    onSuccess() {
+      Toast.success("安装成功");
+      queryClient.invalidateQueries({ queryKey: ["plugins"] });
+    },
+  });
+
+  const { mutateAsync: handleUpdateAnnotations } = useMutation({
+    mutationKey: ["update-plugin-annotations"],
+    mutationFn: async ({
+      plugin,
+      additionalAnnotations,
+    }: {
+      plugin: Plugin;
+      additionalAnnotations: Record<string, string>;
+    }) => {
+      const { data: pluginToUpdate } = await apiClient.extension.plugin.getpluginHaloRunV1alpha1Plugin({
+        name: plugin.metadata.name,
+      });
+      pluginToUpdate.metadata.annotations = {
+        ...pluginToUpdate.metadata.annotations,
+        ...additionalAnnotations,
+      };
+      return await apiClient.extension.plugin.updatepluginHaloRunV1alpha1Plugin(
+        {
+          name: plugin.metadata.name,
+          plugin: pluginToUpdate,
+        },
+        { mute: true }
+      );
+    },
+    retry: 3,
+  });
+
+  const { isLoading: upgrading, mutate: handleUpgrade } = useMutation({
+    mutationKey: ["upgrade"],
+    mutationFn: async () => {
+      const downloadUrl = await getDownloadUrl();
+
+      if (!downloadUrl) {
+        return;
+      }
+
+      if (!matchedPlugin.value) {
+        Toast.error("未找到匹配的插件");
+        return;
+      }
+
+      const { data: upgradedPlugin } = await apiClient.plugin.upgradePluginFromUri({
+        name: matchedPlugin.value.metadata.name,
+        upgradeFromUriRequest: { uri: downloadUrl },
+      });
+
+      if (await checkPluginUpgradeStatus(matchedPlugin.value, app.value?.latestRelease?.spec.version)) {
+        return upgradedPlugin;
+      }
+      return;
+    },
+    onSuccess() {
+      Toast.success("升级成功");
+      queryClient.invalidateQueries({ queryKey: ["plugins"] });
+    },
+  });
+
+  function checkPluginUpgradeStatus(plugin: Plugin, expectVersion?: string) {
+    const maxRetry = 5;
+    let retryCount = 0;
+    return new Promise((resolve, reject) => {
+      const check = () => {
+        if (retryCount >= maxRetry) {
+          reject(false);
+          return;
+        }
+        apiClient.extension.plugin
+          .getpluginHaloRunV1alpha1Plugin({ name: plugin.metadata.name })
+          .then((response) => {
+            const { version } = response.data.spec;
+            if (version === expectVersion) {
+              resolve(true);
+            } else {
+              setTimeout(check, 1000);
+              retryCount++;
+            }
+          })
+          .catch(() => {
+            reject(false);
+          });
+      };
+      check();
+    });
+  }
+
+  return { handleInstall, installing, handleUpgrade, upgrading };
+}
+
+function useThemeAppControl(app: Ref<ApplicationSearchResult | undefined>) {
+  const queryClient = useQueryClient();
+  const { getDownloadUrl } = useAppRelease(app);
+  const { matchedTheme } = useAppCompare(app);
+
+  const { mutate: handleInstall, isLoading: installing } = useMutation({
+    mutationKey: ["install-theme"],
+    mutationFn: async () => {
+      const downloadUrl = await getDownloadUrl();
+      if (!downloadUrl) {
+        return;
+      }
+      const { data: theme } = await apiClient.theme.installThemeFromUri({
+        installFromUriRequest: { uri: downloadUrl },
+      });
+      return await handleUpdateAnnotations({
+        theme,
+        additionalAnnotations: {
+          [STORE_APP_ID]: app.value?.application.metadata.name || "",
+        },
+      });
+    },
+    onSuccess() {
+      Toast.success("安装成功");
+      queryClient.invalidateQueries({ queryKey: ["installed-themes"] });
+    },
+  });
+
+  const { mutateAsync: handleUpdateAnnotations } = useMutation({
+    mutationKey: ["update-theme-annotations"],
+    mutationFn: async ({
+      theme,
+      additionalAnnotations,
+    }: {
+      theme: Theme;
+      additionalAnnotations: Record<string, string>;
+    }) => {
+      const { data: themeToUpdate } = await apiClient.extension.theme.getthemeHaloRunV1alpha1Theme({
+        name: theme.metadata.name,
+      });
+      themeToUpdate.metadata.annotations = {
+        ...themeToUpdate.metadata.annotations,
+        ...additionalAnnotations,
+      };
+      return await apiClient.extension.theme.updatethemeHaloRunV1alpha1Theme(
+        {
+          name: theme.metadata.name,
+          theme: themeToUpdate,
+        },
+        { mute: true }
+      );
+    },
+    retry: 3,
+  });
+
+  const { isLoading: upgrading, mutate: handleUpgrade } = useMutation({
+    mutationKey: ["upgrade-theme"],
+    mutationFn: async () => {
+      const downloadUrl = await getDownloadUrl();
+      if (!downloadUrl) {
+        return;
+      }
+
+      if (!matchedTheme.value) {
+        Toast.error("未找到匹配的主题");
+        return;
+      }
+
+      const { data: upgradedTheme } = await apiClient.theme.upgradeThemeFromUri({
+        name: matchedTheme.value.metadata.name,
+        upgradeFromUriRequest: { uri: downloadUrl },
+      });
+
+      if (await checkThemeUpgradeStatus(matchedTheme.value, app.value?.latestRelease?.spec.version)) {
+        return upgradedTheme;
+      }
+      return;
+    },
+    onSuccess() {
+      Toast.success("升级成功");
+      queryClient.invalidateQueries({ queryKey: ["installed-themes"] });
+    },
+  });
+
+  function checkThemeUpgradeStatus(theme: Theme, expectVersion?: string) {
+    const maxRetry = 5;
+    let retryCount = 0;
+    return new Promise((resolve, reject) => {
+      const check = () => {
+        if (retryCount >= maxRetry) {
+          reject(false);
+          return;
+        }
+        apiClient.extension.theme
+          .getthemeHaloRunV1alpha1Theme({ name: theme.metadata.name })
+          .then((response) => {
+            const { version } = response.data.spec;
+            if (version === expectVersion) {
+              resolve(true);
+            } else {
+              setTimeout(check, 1000);
+              retryCount++;
+            }
+          })
+          .catch(() => {
+            reject(false);
+          });
+      };
+      check();
+    });
+  }
+
+  return { handleInstall, installing, handleUpgrade, upgrading };
+}
+
+function useAppRelease(app: Ref<ApplicationSearchResult | undefined>) {
+  async function getDownloadUrl() {
+    if (!app.value) {
+      Toast.error("应用不存在");
+      return;
+    }
+
+    if (!app.value.latestRelease) {
+      Toast.error("此应用没有最新的发行版本");
+      return;
+    }
+
+    const { name: appName } = app.value.application.metadata;
+    const { data: appDetail } = await storeApiClient.get<ApplicationDetail>(
+      `/apis/api.store.halo.run/v1alpha1/applications/${appName}`
+    );
+
+    if (!appDetail.latestRelease?.assets?.length) {
+      Toast.error("此应用的最新版本没有可安装的资源");
+      return;
+    }
+
+    const { name: releaseName } = appDetail.latestRelease.release.metadata;
+    const { name: assetName } = appDetail.latestRelease.assets[0].metadata;
+
+    return `${
+      import.meta.env.VITE_APP_STORE_BACKEND
+    }/store/apps/${appName}/releases/download/${releaseName}/assets/${assetName}`;
+  }
+
+  return { getDownloadUrl };
 }

--- a/console/src/composables/use-halo-version.ts
+++ b/console/src/composables/use-halo-version.ts
@@ -10,6 +10,7 @@ export function useHaloVersion() {
       });
       return data?.build?.version;
     },
+    staleTime: 2000,
   });
   return { haloVersion };
 }

--- a/console/src/composables/use-plugin-version.ts
+++ b/console/src/composables/use-plugin-version.ts
@@ -5,13 +5,14 @@ import { useQuery } from "@tanstack/vue-query";
 import { computed, type Ref } from "vue";
 import semver from "semver";
 import { useHaloVersion } from "./use-halo-version";
+import { STORE_APP_ID } from "@/constant";
 
 export function usePluginVersion(plugin: Ref<Plugin | undefined>) {
   const { haloVersion } = useHaloVersion();
 
   // TODO: 可能需要专门的最新版本应用列表接口
   const { data: storePlugins } = useQuery<ListResponse<ApplicationSearchResult>>({
-    queryKey: ["store-apps"],
+    queryKey: ["plugin-apps"],
     queryFn: async () => {
       const { data } = await storeApiClient.get<ListResponse<ApplicationSearchResult>>(
         `/apis/api.store.halo.run/v1alpha1/applications`,
@@ -23,10 +24,13 @@ export function usePluginVersion(plugin: Ref<Plugin | undefined>) {
       );
       return data;
     },
+    staleTime: 1000,
   });
 
   const matchedApp = computed(() => {
-    return storePlugins.value?.items.find((app) => app.application.spec.displayName === plugin.value?.spec.displayName);
+    return storePlugins.value?.items.find(
+      (app) => app.application.metadata.name === plugin.value?.metadata.annotations?.[STORE_APP_ID]
+    );
   });
 
   const hasUpdate = computed(() => {

--- a/console/src/composables/use-theme-version.ts
+++ b/console/src/composables/use-theme-version.ts
@@ -5,13 +5,14 @@ import { useQuery } from "@tanstack/vue-query";
 import { computed, type Ref } from "vue";
 import semver from "semver";
 import { useHaloVersion } from "./use-halo-version";
+import { STORE_APP_ID } from "@/constant";
 
 export function useThemeVersion(theme: Ref<Theme | undefined>) {
   const { haloVersion } = useHaloVersion();
 
   // TODO: 可能需要专门的最新版本应用列表接口
   const { data: storeThemes } = useQuery<ListResponse<ApplicationSearchResult>>({
-    queryKey: ["store-apps"],
+    queryKey: ["theme-apps"],
     queryFn: async () => {
       const { data } = await storeApiClient.get<ListResponse<ApplicationSearchResult>>(
         `/apis/api.store.halo.run/v1alpha1/applications`,
@@ -23,10 +24,13 @@ export function useThemeVersion(theme: Ref<Theme | undefined>) {
       );
       return data;
     },
+    staleTime: 1000,
   });
 
   const matchedApp = computed(() => {
-    return storeThemes.value?.items.find((app) => app.application.spec.displayName === theme.value?.spec.displayName);
+    return storeThemes.value?.items.find(
+      (app) => app.application.metadata.name === theme.value?.metadata.annotations?.[STORE_APP_ID]
+    );
   });
 
   const hasUpdate = computed(() => {

--- a/console/src/constant/annotations.ts
+++ b/console/src/constant/annotations.ts
@@ -1,0 +1,1 @@
+export const STORE_APP_ID = "store.halo.run/app-id";

--- a/console/src/constant/index.ts
+++ b/console/src/constant/index.ts
@@ -1,3 +1,5 @@
+export * from "./annotations";
+
 export enum AppType {
   PLUGIN = "PLUGIN",
   THEME = "THEME",


### PR DESCRIPTION
重构本地插件和主题与应用市场的应用的匹配逻辑。

1. 从应用市场安装插件或者主题时，会自动为插件或者主题资源的 `metadata.annotations` 添加 `store.halo.run/app-id`，以建立绑定关系。
2. 检测更新、是否已安装都基于 `store.halo.run/app-id`。
3. 如果是从非应用市场安装的插件和主题（比如上传），则不会检测更新、是否已安装。
4. 后续可以考虑支持从应用市场覆盖安装。

此改动主要是为了防止本地插件和主题与应用市场冲突（同名但并不是同一个应用）。

/kind improvement

```release-note
None
```