### PR TITLE
feat: add supports for install app in releases

### DIFF
--- a/console/src/components/AppDetailModal.vue
+++ b/console/src/components/AppDetailModal.vue
@@ -130,7 +130,7 @@ const { action } = useAppControl(app);
                   <DetailReadme :app="appDetail" />
                 </VTabItem>
                 <VTabItem id="releases" label="版本">
-                  <DetailReleases :app="appDetail" />
+                  <DetailReleases :app="app" />
                 </VTabItem>
                 <VTabItem id="comment" label="讨论"> </VTabItem>
               </VTabs>

--- a/console/src/components/detail/DetailReleaseItem.vue
+++ b/console/src/components/detail/DetailReleaseItem.vue
@@ -1,0 +1,90 @@
+<script lang="ts" setup>
+import { useAppControl } from "@/composables/use-app-control";
+import type { ApplicationSearchResult, ReleaseDetail } from "@/types";
+import { relativeTimeTo } from "@/utils/date";
+import prettyBytes from "pretty-bytes";
+import { toRefs } from "vue";
+import TablerCloudDownload from "~icons/tabler/cloud-download";
+
+const props = withDefaults(
+  defineProps<{
+    release: ReleaseDetail;
+    app: ApplicationSearchResult;
+  }>(),
+  {}
+);
+
+const { app } = toRefs(props);
+
+const { handleInstall, installing } = useAppControl(app);
+</script>
+
+<template>
+  <div class="as-flex as-flex-col as-gap-4 lg:as-flex-row">
+    <div class="as-w-48">
+      <h2 class="as-text-xl as-font-semibold">
+        {{ release.release.spec.version }}
+      </h2>
+      <div class="as-inline-flex as-flex-col as-items-start as-gap-1 as-text-xs as-text-gray-600">
+        <span>{{ release.owner?.displayName || release.owner?.name }}</span>
+        <span title="2023-08-01 17:22"> 发布于 {{ relativeTimeTo(release.release.metadata.creationTimestamp) }} </span>
+      </div>
+    </div>
+    <div class="as-flex-1 as-rounded-md as-border">
+      <div class="as-flex as-items-center as-justify-between as-p-4">
+        <div class="as-inline-flex as-flex-wrap as-items-center as-space-x-3">
+          <h1 class="as-text-2xl as-font-bold sm:as-text-3xl">
+            {{ release.release.spec.displayName }}
+          </h1>
+          <span
+            v-if="release.latest"
+            class="as-inline-flex as-items-center as-rounded as-bg-blue-100 as-px-2 as-py-0.5 as-text-xs as-font-medium as-text-blue-800"
+          >
+            最新
+          </span>
+          <span
+            v-if="release.release.spec.preRelease"
+            className="as-inline-flex as-items-center as-rounded as-bg-green-100 as-px-2 as-py-0.5 as-text-xs as-font-medium as-text-green-800"
+          >
+            预发布
+          </span>
+        </div>
+        <div class="text-gray-600 as-text-sm">
+          {{ release.release.spec.requires }}
+        </div>
+      </div>
+      <article class="markdown-body as-border-t !as-bg-transparent as-p-4" v-html="release.notes?.html"></article>
+      <div v-if="release.assets?.length !== 0" class="as-border-t as-p-4">
+        <div class="as-mb-4 as-inline-flex as-items-center">
+          <TablerCloudDownload class="as-mr-2 !as-h-5 !as-w-5" />
+          <h2 class="as-text-base as-font-semibold">资源下载</h2>
+        </div>
+        <ul class="as-divide-y as-divide-gray-200 as-overflow-hidden as-rounded-md as-border">
+          <li
+            v-for="asset in release.assets"
+            :key="asset.metadata.name"
+            class="as-flex as-cursor-pointer as-items-center as-justify-between as-px-3 as-py-2 hover:as-bg-gray-100"
+          >
+            <div class="as-inline-flex as-flex-col as-gap-0.5 as-truncate">
+              <span class="as-truncate as-text-sm as-font-semibold">
+                {{ asset.spec.name }}
+              </span>
+              <span class="as-text-xs as-text-gray-600">
+                {{ prettyBytes(asset.spec.size || 0) }}
+              </span>
+            </div>
+            <div>
+              <span
+                class="as-text-sm as-text-blue-600 hover:as-text-blue-500"
+                :class="{ 'as-pointer-events-none': installing }"
+                @click="handleInstall()"
+              >
+                {{ installing ? "安装中" : "安装" }}
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>

--- a/console/src/components/detail/DetailReleases.vue
+++ b/console/src/components/detail/DetailReleases.vue
@@ -1,25 +1,24 @@
 <script lang="ts" setup>
-import type { ApplicationDetail } from "@/types";
-import { relativeTimeTo } from "@/utils/date";
+import type { ApplicationSearchResult, ReleaseDetail } from "@/types";
 import storeApiClient from "@/utils/store-api-client";
 import { useQuery } from "@tanstack/vue-query";
-import prettyBytes from "pretty-bytes";
 import { computed } from "vue";
-import TablerCloudDownload from "~icons/tabler/cloud-download";
+import DetailReleaseItem from "./DetailReleaseItem.vue";
+import { VLoading } from "@halo-dev/components";
 
 const props = withDefaults(
   defineProps<{
-    app?: ApplicationDetail;
+    app?: ApplicationSearchResult;
   }>(),
   {
     app: undefined,
   }
 );
 
-const { data: releases } = useQuery({
+const { isLoading, data: releases } = useQuery<ReleaseDetail[]>({
   queryKey: ["store-app-releases", props.app],
   queryFn: async () => {
-    const { data } = await storeApiClient.get(
+    const { data } = await storeApiClient.get<ReleaseDetail[]>(
       `/apis/api.store.halo.run/v1alpha1/applications/${props.app?.application.metadata.name}/releases`
     );
     return data;
@@ -31,69 +30,18 @@ const { data: releases } = useQuery({
 <template>
   <div id="app-releases">
     <div class="as-flex as-flex-col as-gap-4">
-      <div v-for="(release, index) in releases" :key="index" class="as-flex as-flex-col as-gap-4 lg:as-flex-row">
-        <div class="as-w-48">
-          <h2 class="as-text-xl as-font-semibold">
-            {{ release.release.spec.version }}
-          </h2>
-          <div class="as-inline-flex as-flex-col as-items-start as-gap-1 as-text-xs as-text-gray-600">
-            <span>{{ release.owner.displayName }}</span>
-            <span title="2023-08-01 17:22">
-              发布于 {{ relativeTimeTo(release.release.metadata.creationTimestamp) }}
-            </span>
-          </div>
-        </div>
-        <div class="as-flex-1 as-rounded-md as-border">
-          <div class="as-flex as-items-center as-justify-between as-p-4">
-            <div class="as-inline-flex as-flex-wrap as-items-center as-space-x-3">
-              <h1 class="as-text-2xl as-font-bold sm:as-text-3xl">
-                {{ release.release.spec.displayName }}
-              </h1>
-              <span
-                v-if="release.latest"
-                class="as-inline-flex as-items-center as-rounded as-bg-blue-100 as-px-2 as-py-0.5 as-text-xs as-font-medium as-text-blue-800"
-              >
-                最新
-              </span>
-              <span
-                v-if="release.release.spec.preRelease"
-                className="as-inline-flex as-items-center as-rounded as-bg-green-100 as-px-2 as-py-0.5 as-text-xs as-font-medium as-text-green-800"
-              >
-                预发布
-              </span>
-            </div>
-            <div class="text-gray-600 as-text-sm">
-              {{ release.release.spec.requires }}
-            </div>
-          </div>
-          <article class="markdown-body as-border-t !as-bg-transparent as-p-4" v-html="release.notes?.html"></article>
-          <div v-if="release.assets?.length !== 0" class="as-border-t as-p-4">
-            <div class="as-mb-4 as-inline-flex as-items-center">
-              <TablerCloudDownload class="as-mr-2 !as-h-5 !as-w-5" />
-              <h2 class="as-text-base as-font-semibold">资源下载</h2>
-            </div>
-            <ul class="as-divide-y as-divide-gray-200 as-overflow-hidden as-rounded-md as-border">
-              <li
-                v-for="asset in release.assets"
-                :key="asset.metadata.name"
-                class="as-flex as-cursor-pointer as-items-center as-justify-between as-px-3 as-py-2 hover:as-bg-gray-100"
-              >
-                <div class="as-inline-flex as-flex-col as-gap-0.5 as-truncate">
-                  <span class="as-truncate as-text-sm as-font-semibold">
-                    {{ asset.spec.name }}
-                  </span>
-                  <span class="as-text-xs as-text-gray-600">
-                    {{ prettyBytes(asset.spec.size || 0) }}
-                  </span>
-                </div>
-                <div>
-                  <span class="as-text-sm as-text-blue-600 hover:as-text-blue-500"> 下载 </span>
-                </div>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
+      <VLoading v-if="isLoading" />
+      <template v-else-if="releases?.length">
+        <DetailReleaseItem
+          v-for="release in releases"
+          :key="release.release.metadata.name"
+          :release="release"
+          :app="app"
+        />
+      </template>
+      <template v-else>
+        <span class="text-sm text-gray-600">暂无已发布的版本</span>
+      </template>
     </div>
   </div>
 </template>


### PR DESCRIPTION
支持在应用详情的 Releases 列表安装主题和插件。

<img width="1255" alt="image" src="https://github.com/halo-dev/plugin-app-store/assets/21301288/315c9c5c-48f7-4447-8944-64c5fa689b73">


```release-note
None
```