### PR TITLE
feat: refactor app-download hook to support binding

### DIFF
--- a/console/postcss.config.js
+++ b/console/postcss.config.js
@@ -3,4 +3,4 @@ module.exports = {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/console/src/components/AppActionButton.vue
+++ b/console/src/components/AppActionButton.vue
@@ -1,0 +1,81 @@
+<script lang="ts" setup>
+import { useAppCompare } from "@/composables/use-app-compare";
+import { useAppDownload } from "@/composables/use-app-download";
+import type { ApplicationSearchResult } from "@/types";
+import { VButton } from "@halo-dev/components";
+import { computed, toRefs } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    app?: ApplicationSearchResult;
+    size?: string;
+  }>(),
+  {
+    app: undefined,
+    size: "default",
+  }
+);
+
+const { app } = toRefs(props);
+
+const { installing, handleInstall } = useAppDownload(app);
+const { isSatisfies, hasInstalled } = useAppCompare(app);
+
+const actions = computed(() => {
+  return [
+    {
+      label: installing?.value ? "安装中" : "安装",
+      type: "default",
+      available:
+        !hasInstalled.value && isSatisfies.value && app.value?.application.spec.priceConfig?.mode !== "ONE_TIME",
+      onClick: handleInstall,
+      loading: installing?.value,
+      disabled: false,
+    },
+    {
+      label: `￥${(app.value?.application.spec.priceConfig?.oneTimePrice || 0) / 100}`,
+      type: "default",
+      // TODO: 需要判断是否已经购买
+      available: app.value?.application.spec.priceConfig?.mode === "ONE_TIME" && !hasInstalled.value,
+      onClick: () => {
+        window.open(`https://halo.run/store/apps/${app.value?.application.metadata.name}/buy`);
+      },
+      loading: false,
+      disabled: false,
+    },
+    {
+      label: "已安装",
+      type: "default",
+      available: hasInstalled.value,
+      onClick: undefined,
+      loading: false,
+      disabled: true,
+    },
+    {
+      label: "版本不兼容",
+      type: "default",
+      available: !isSatisfies.value && !hasInstalled.value,
+      onClick: undefined,
+      loading: false,
+      disabled: true,
+    },
+  ];
+});
+
+const action = computed(() => {
+  return actions.value.find((action) => action.available);
+});
+</script>
+
+<template>
+  <VButton
+    v-if="action"
+    :size="size"
+    :type="action.type"
+    :disabled="action.disabled"
+    :loading="action.loading"
+    @click="action.onClick"
+  >
+    {{ action.label }}
+  </VButton>
+</template>

--- a/console/src/components/AppCard.vue
+++ b/console/src/components/AppCard.vue
@@ -1,12 +1,11 @@
 <script lang="ts" setup>
-import { useAppControl } from "@/composables/use-app-control";
 import type { ApplicationSearchResult } from "@/types";
 import { relativeTimeTo } from "@/utils/date";
-import { VButton } from "@halo-dev/components";
 import { toRefs } from "vue";
 import { computed } from "vue";
 import { prependDomain } from "@/utils/resource";
 import AppVersionCheckBar from "./AppVersionCheckBar.vue";
+import AppActionButton from "./AppActionButton.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -40,8 +39,6 @@ const vendor = computed(() => {
     logo: props.app.owner.avatar,
   };
 });
-
-const { action } = useAppControl(app);
 </script>
 
 <template>
@@ -155,16 +152,7 @@ const { action } = useAppControl(app);
           </span>
         </div>
         <div>
-          <VButton
-            v-if="action"
-            size="sm"
-            :type="action.type"
-            :disabled="action.disabled"
-            :loading="action.loading"
-            @click="action.onClick"
-          >
-            {{ action.label }}
-          </VButton>
+          <AppActionButton :app="app" size="sm" />
         </div>
       </div>
     </div>

--- a/console/src/components/AppDetailModal.vue
+++ b/console/src/components/AppDetailModal.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { IconLink, VButton, VLoading, VModal, VSpace, VTabItem, VTabs } from "@halo-dev/components";
+import { IconLink, VLoading, VModal, VSpace, VTabItem, VTabs } from "@halo-dev/components";
 import { useQuery } from "@tanstack/vue-query";
 import { ref } from "vue";
 import { computed } from "vue";
@@ -7,11 +7,12 @@ import { toRefs } from "vue";
 import { prependDomain } from "@/utils/resource";
 import type { ApplicationSearchResult } from "@/types";
 import storeApiClient from "@/utils/store-api-client";
-import { useAppControl } from "@/composables/use-app-control";
 import DetailSidebar from "./detail/DetailSidebar.vue";
 import DetailReadme from "./detail/DetailReadme.vue";
 import DetailReleases from "./detail/DetailReleases.vue";
 import AppVersionCheckBar from "./AppVersionCheckBar.vue";
+import AppActionButton from "./AppActionButton.vue";
+
 const props = withDefaults(
   defineProps<{
     visible: boolean;
@@ -65,8 +66,6 @@ const title = computed(() => {
 });
 
 const activeId = ref(props.tab);
-
-const { action } = useAppControl(app);
 </script>
 
 <template>
@@ -141,15 +140,7 @@ const { action } = useAppControl(app);
     </div>
     <template #footer>
       <VSpace>
-        <VButton
-          v-if="action"
-          :type="action.type"
-          :disabled="action.disabled"
-          :loading="action.loading"
-          @click="action.onClick"
-        >
-          {{ action.label }}
-        </VButton>
+        <AppActionButton :app="app" />
         <AppVersionCheckBar :app="app" />
       </VSpace>
     </template>

--- a/console/src/components/AppVersionCheckBar.vue
+++ b/console/src/components/AppVersionCheckBar.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import AppDetailModal from "./AppDetailModal.vue";
 import { nextTick, ref, toRefs } from "vue";
-import { useAppControl } from "@/composables/use-app-control";
+import { useAppDownload } from "@/composables/use-app-download";
 import RiArrowUpCircleLine from "~icons/ri/arrow-up-circle-line";
 import type { ApplicationSearchResult } from "@/types";
 import { useAppCompare } from "@/composables/use-app-compare";
@@ -19,7 +19,7 @@ const { app } = toRefs(props);
 
 const { hasUpdate, isSatisfies } = useAppCompare(app);
 
-const { upgrading, handleUpgrade } = useAppControl(app);
+const { upgrading, handleUpgrade } = useAppDownload(app);
 
 const detailModal = ref(false);
 const detailModalVisible = ref(false);

--- a/console/src/components/ThemeOrPluginVersionCheckBar.vue
+++ b/console/src/components/ThemeOrPluginVersionCheckBar.vue
@@ -3,7 +3,7 @@ import type { Plugin, Theme } from "@halo-dev/api-client";
 import AppDetailModal from "./AppDetailModal.vue";
 import { nextTick, ref, toRefs } from "vue";
 import { usePluginVersion } from "@/composables/use-plugin-version";
-import { useAppControl } from "@/composables/use-app-control";
+import { useAppDownload } from "@/composables/use-app-download";
 import RiArrowUpCircleLine from "~icons/ri/arrow-up-circle-line";
 import { useThemeVersion } from "@/composables/use-theme-version";
 import { useAppCompare } from "@/composables/use-app-compare";
@@ -38,7 +38,7 @@ function useVersion() {
 
 const { hasUpdate, matchedApp } = useVersion();
 const { isSatisfies } = useAppCompare(matchedApp);
-const { upgrading, handleUpgrade } = useAppControl(matchedApp);
+const { upgrading, handleUpgrade } = useAppDownload(matchedApp);
 
 const detailModal = ref(false);
 const detailModalVisible = ref(false);

--- a/console/src/constant/exception.ts
+++ b/console/src/constant/exception.ts
@@ -1,0 +1,2 @@
+export const PLUGIN_ALREADY_EXISTS_TYPE = "https://halo.run/probs/plugin-alreay-exists";
+export const THEME_ALREADY_EXISTS_TYPE = "https://halo.run/probs/theme-alreay-exists";

--- a/console/src/constant/index.ts
+++ b/console/src/constant/index.ts
@@ -1,4 +1,5 @@
 export * from "./annotations";
+export * from "./exception";
 
 export enum AppType {
   PLUGIN = "PLUGIN",

--- a/console/src/types/core.ts
+++ b/console/src/types/core.ts
@@ -1,0 +1,21 @@
+export interface PluginInstallationErrorResponse {
+  detail: string;
+  instance: string;
+  pluginName: string;
+  requestId: string;
+  status: number;
+  timestamp: string;
+  title: string;
+  type: string;
+}
+
+export interface ThemeInstallationErrorResponse {
+  detail: string;
+  instance: string;
+  themeName: string;
+  requestId: string;
+  status: number;
+  timestamp: string;
+  title: string;
+  type: string;
+}


### PR DESCRIPTION
1. 支持从应用市场强制安装（绑定已有插件或者主题）。
2. 支持从 Release 下载不同的版本。

/kind feature

Fixes #5 

可测试 JAR 包：https://github.com/halo-dev/plugin-app-store/actions/runs/6106001042

需要测试：

1. 从本地安装若干主题和插件，然后尝试从应用市场重新安装，观察是否可以绑定。
2. 测试从应用市场全新安装主题或者插件，以及更新主题和插件。
3. 测试从应用详情的 Release 页面下载不同的版本。

```release-note
None
```