### PR TITLE
feat: add default border color for app card

### DIFF
--- a/console/src/components/AppCard.vue
+++ b/console/src/components/AppCard.vue
@@ -46,7 +46,7 @@ const { action } = useAppControl(app);
 
 <template>
   <div
-    class="group as-relative as-flex as-grid-cols-1 as-flex-col as-overflow-hidden as-rounded as-bg-white as-p-0 as-shadow-sm as-transition-all as-duration-500 hover:as-shadow-md hover:as-ring-1 sm:as-grid sm:as-grid-cols-7 sm:as-p-2"
+    class="group as-relative as-flex as-grid-cols-1 as-flex-col as-overflow-hidden as-rounded as-bg-white as-p-0 as-shadow-sm as-ring-1 as-ring-gray-100 as-transition-all as-duration-500 hover:as-shadow-md hover:as-ring-inherit sm:as-grid sm:as-grid-cols-7 sm:as-p-2"
     :class="[
       {
         '!as-grid-cols-1 !as-p-0': !block,


### PR DESCRIPTION
为应用卡片组件添加默认的边框颜色，防止与背景融在一起。

before:

<img width="1300" alt="image" src="https://github.com/halo-dev/plugin-app-store/assets/21301288/faf91688-decb-4ba6-8c2e-2a4b0625dc8c">

after:

<img width="1294" alt="image" src="https://github.com/halo-dev/plugin-app-store/assets/21301288/5934a8a2-be3c-47f5-8ee4-12c40d161e91">

/kind improvement

```release-note
None
```