### PR TITLE
fix: the download is empty when downloads is undefined

### DIFF
--- a/console/src/components/detail/DetailSidebar.vue
+++ b/console/src/components/detail/DetailSidebar.vue
@@ -3,7 +3,6 @@ import type { ApplicationDetail } from "@/types";
 import { relativeTimeTo } from "@/utils/date";
 import TablerGraph from "~icons/tabler/graph";
 import TablerDownload from "~icons/tabler/download";
-
 withDefaults(
   defineProps<{
     app?: ApplicationDetail;
@@ -120,7 +119,7 @@ withDefaults(
                     <span class="as-text-xs as-text-gray-500">下载</span>
                   </div>
                   <span class="as-font-semibold as-tabular-nums">
-                    {{ app.downloads }}
+                    {{ app.downloads || 0 }}
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
解决当下载量为undefined时，下载数不显示 
fixes https://github.com/halo-dev/plugin-app-store/issues/10

```release-note
修复应用详情下载量为 0 时的显示问题
```