### PR TITLE
feat: add plugin and theme binding check field

### DIFF
--- a/console/src/components/entity-fields/PluginBindingCheckField.vue
+++ b/console/src/components/entity-fields/PluginBindingCheckField.vue
@@ -1,0 +1,19 @@
+<script lang="ts" setup>
+import type { Plugin } from "@halo-dev/api-client";
+import { VEntityField, VStatusDot } from "@halo-dev/components";
+
+withDefaults(
+  defineProps<{
+    plugin: Plugin;
+  }>(),
+  {}
+);
+</script>
+
+<template>
+  <VEntityField>
+    <template #description>
+      <VStatusDot v-tooltip="`未绑定应用市场，在应用市场覆盖安装之后即可检测新版本`" state="default" />
+    </template>
+  </VEntityField>
+</template>

--- a/console/src/components/operation-items/ThemeBindingCheckOperationItem.vue
+++ b/console/src/components/operation-items/ThemeBindingCheckOperationItem.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import type { Theme } from "@halo-dev/api-client";
+import { VStatusDot } from "@halo-dev/components";
+
+withDefaults(
+  defineProps<{
+    theme: Theme;
+  }>(),
+  {}
+);
+</script>
+
+<template>
+  <VStatusDot v-tooltip="`未绑定应用市场，在应用市场覆盖安装之后即可检测新版本`" state="default" />
+</template>

--- a/console/src/index.ts
+++ b/console/src/index.ts
@@ -9,6 +9,7 @@ import AppStore from "./views/AppStore.vue";
 import type { Plugin, Theme } from "@halo-dev/api-client";
 import PluginVersionCheckField from "./components/entity-fields/PluginVersionCheckField.vue";
 import ThemeVersionCheckOperationItem from "./components/operation-items/ThemeVersionCheckOperationItem.vue";
+import PluginBindingCheckField from "./components/entity-fields/PluginBindingCheckField.vue";
 import ViewAppStoreOperationItem from "./components/operation-items/ViewAppStoreOperationItem.vue";
 import { STORE_APP_ID } from "./constant";
 
@@ -69,6 +70,15 @@ export default definePlugin({
           props: {
             plugin: plugin,
           },
+        },
+        {
+          priority: 42,
+          position: "end",
+          component: markRaw(PluginBindingCheckField),
+          props: {
+            plugin: plugin,
+          },
+          hidden: !!plugin.value.metadata.annotations?.[STORE_APP_ID],
         },
       ];
     },

--- a/console/src/index.ts
+++ b/console/src/index.ts
@@ -10,6 +10,7 @@ import type { Plugin, Theme } from "@halo-dev/api-client";
 import PluginVersionCheckField from "./components/entity-fields/PluginVersionCheckField.vue";
 import ThemeVersionCheckOperationItem from "./components/operation-items/ThemeVersionCheckOperationItem.vue";
 import PluginBindingCheckField from "./components/entity-fields/PluginBindingCheckField.vue";
+import ThemeBindingCheckOperationItem from "./components/operation-items/ThemeBindingCheckOperationItem.vue";
 import ViewAppStoreOperationItem from "./components/operation-items/ViewAppStoreOperationItem.vue";
 import { STORE_APP_ID } from "./constant";
 
@@ -90,6 +91,14 @@ export default definePlugin({
           props: {
             theme,
           },
+        },
+        {
+          priority: 1,
+          component: markRaw(ThemeBindingCheckOperationItem),
+          props: {
+            theme,
+          },
+          hidden: !!theme.value.metadata.annotations?.[STORE_APP_ID],
         },
       ];
     },


### PR DESCRIPTION
在插件列表添加绑定检测的显示，此功能是为了方便使用者查看哪些已安装的插件和主题还没有和应用市场绑定。

<img width="762" alt="image" src="https://github.com/halo-dev/plugin-app-store/assets/21301288/be5b9c0f-8cb1-41b8-b0d6-4349d250f4d0">

Fixes #22 

/kind improvement

```release-note
支持在已安装的插件和主题列表显示未绑定应用市场的提示。
```