### PR TITLE
chore: update app store backend server address

### DIFF
--- a/console/.env
+++ b/console/.env
@@ -1,1 +1,1 @@
-VITE_APP_STORE_BACKEND=https://halo.run
+VITE_APP_STORE_BACKEND=https://www.halo.run

--- a/console/src/components/AgreementsModal.vue
+++ b/console/src/components/AgreementsModal.vue
@@ -81,7 +81,7 @@ const { isLoading, mutate } = useMutation({
       <FormKit v-model="formState.termsOfService" type="checkbox">
         <template #label>
           <span class="formkit-label formkit-invalid:text-red-500 as-block as-text-sm as-font-medium as-text-gray-700">
-            我已阅读并同意：<a href="https://halo.run/terms-of-service" target="_blank">《Halo 应用市场服务条款》</a>
+            我已阅读并同意：<a href="https://www.halo.run/terms-of-service" target="_blank">《Halo 应用市场服务条款》</a>
           </span>
         </template>
       </FormKit>

--- a/console/src/components/AppActionButton.vue
+++ b/console/src/components/AppActionButton.vue
@@ -38,7 +38,7 @@ const actions = computed(() => {
       // TODO: 需要判断是否已经购买
       available: app.value?.application.spec.priceConfig?.mode === "ONE_TIME" && !hasInstalled.value,
       onClick: () => {
-        window.open(`https://halo.run/store/apps/${app.value?.application.metadata.name}/buy`);
+        window.open(`https://www.halo.run/store/apps/${app.value?.application.metadata.name}/buy`);
       },
       loading: false,
       disabled: false,

--- a/console/src/components/AppDetailModal.vue
+++ b/console/src/components/AppDetailModal.vue
@@ -85,7 +85,7 @@ watch(
     storeApiClient.post(`/apis/api.store.halo.run/tracker`, {
       type: "pageView",
       payload: {
-        hostname: "halo.run",
+        hostname: "www.halo.run",
         screen: `${width}x${height}`,
         language: language,
         title: `应用：${value.application.spec.displayName} - Halo 建站 - 强大易用的开源建站工具`,

--- a/console/src/components/AppDetailModal.vue
+++ b/console/src/components/AppDetailModal.vue
@@ -115,7 +115,7 @@ watch(
           delay: 300,
         }"
       >
-        <a :href="`https://halo.run/store/apps/${app?.application.metadata.name}`" target="_blank">
+        <a :href="`https://www.halo.run/store/apps/${app?.application.metadata.name}`" target="_blank">
           <IconLink />
         </a>
       </span>

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -15,7 +15,7 @@ spec:
               children:
                 - $el: a
                   attrs:
-                    href: https://halo.run/terms-of-service
+                    href: https://www.halo.run/terms-of-service
                     target: _blank
                     class: "as-text-indigo-600"
                   children: "《Halo 应用市场服务条款》"


### PR DESCRIPTION
目前 Halo 官网已经主要使用 www.halo.run ，虽然原有的 halo.run 会重定向到新域名，但为了减少不必要的请求，所以直接切换到 www.halo.run

/kind improvement

```release-note
None
```