### PR TITLE
feat: store query params to location href in app store page

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -13,6 +13,7 @@
     "@halo-dev/console-shared": "^2.9.0",
     "@tanstack/vue-query": "^4.34.4",
     "@vueuse/core": "^10.4.1",
+    "@vueuse/router": "^10.4.1",
     "axios": "^1.5.0",
     "dayjs": "^1.11.9",
     "github-markdown-css": "^5.2.0",

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   '@vueuse/core':
     specifier: ^10.4.1
     version: 10.4.1(vue@3.3.4)
+  '@vueuse/router':
+    specifier: ^10.4.1
+    version: 10.4.1(vue-router@4.2.4)(vue@3.3.4)
   axios:
     specifier: ^1.5.0
     version: 1.5.0
@@ -1094,6 +1097,19 @@ packages:
 
   /@vueuse/metadata@10.4.1:
     resolution: {integrity: sha512-2Sc8X+iVzeuMGHr6O2j4gv/zxvQGGOYETYXEc41h0iZXIRnRbJZGmY/QP8dvzqUelf8vg0p/yEA5VpCEu+WpZg==}
+    dev: false
+
+  /@vueuse/router@10.4.1(vue-router@4.2.4)(vue@3.3.4):
+    resolution: {integrity: sha512-gsMuSIDTUj7Gt91pnFbrhUCDaGObceQAs3+XGguRNj/WgzqLpywe37mE4645McDspEbig/n9nvn8SSmo6XRvPw==}
+    peerDependencies:
+      vue-router: '>=4.0.0-rc.1'
+    dependencies:
+      '@vueuse/shared': 10.4.1(vue@3.3.4)
+      vue-demi: 0.14.5(vue@3.3.4)
+      vue-router: 4.2.4(vue@3.3.4)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
     dev: false
 
   /@vueuse/shared@10.4.1(vue@3.3.4):


### PR DESCRIPTION
将应用市场页面的接口查询参数存储在地址栏。

<img width="1111" alt="image" src="https://github.com/halo-dev/plugin-app-store/assets/21301288/16d2401f-bad6-4ea9-81a3-6b04cd5fd2c4">

/kind feature

```release-note
保存应用市场页面的查询参数到地址栏。
```