### PR TITLE
refactor: app version requires check

### DIFF
--- a/console/src/components/detail/DetailReleaseItem.vue
+++ b/console/src/components/detail/DetailReleaseItem.vue
@@ -16,6 +16,7 @@ import type { AxiosError } from "axios";
 import storeApiClient from "@/utils/store-api-client";
 import PaymentCheckModal from "../PaymentCheckModal.vue";
 import { usePaymentCheckModal } from "@/composables/use-payment-check-modal";
+import { satisfiesRequires } from "@/utils/version";
 
 const props = withDefaults(
   defineProps<{
@@ -56,8 +57,7 @@ const hasInstalled = computed(() => {
 
 const isSatisfies = computed(() => {
   const { requires } = props.release.release.spec;
-  if (!haloVersion.value || !requires) return false;
-  return semver.satisfies(haloVersion.value, requires, { includePrerelease: true });
+  return satisfiesRequires(haloVersion.value, requires);
 });
 
 async function getDownloadUrl(asset: ApplicationReleaseAsset) {

--- a/console/src/composables/use-app-compare.ts
+++ b/console/src/composables/use-app-compare.ts
@@ -5,6 +5,7 @@ import semver from "semver";
 import { useHaloVersion } from "./use-halo-version";
 import { useFetchInstalledPlugins } from "./use-plugin";
 import { useFetchInstalledThemes } from "./use-theme";
+import { satisfiesRequires } from "@/utils/version";
 
 export function useAppCompare(app: Ref<ApplicationSearchResult | undefined>) {
   const { haloVersion } = useHaloVersion();
@@ -64,12 +65,8 @@ export function useAppCompare(app: Ref<ApplicationSearchResult | undefined>) {
     if (!app.value?.latestRelease) {
       return false;
     }
-
     const { requires } = app.value.latestRelease.spec;
-
-    if (!haloVersion.value || !requires) return false;
-
-    return semver.satisfies(haloVersion.value, requires, { includePrerelease: true });
+    return satisfiesRequires(haloVersion.value, requires);
   });
 
   return {

--- a/console/src/composables/use-plugin-version.ts
+++ b/console/src/composables/use-plugin-version.ts
@@ -7,6 +7,7 @@ import semver from "semver";
 import { useHaloVersion } from "./use-halo-version";
 import { STORE_APP_ID } from "@/constant";
 import { useFetchInstalledPlugins } from "./use-plugin";
+import { satisfiesRequires } from "@/utils/version";
 
 export function usePluginVersion(plugin: Ref<Plugin | undefined>) {
   const { haloVersion } = useHaloVersion();
@@ -62,12 +63,7 @@ export function usePluginVersion(plugin: Ref<Plugin | undefined>) {
       return false;
     }
     const { requires } = matchedApp.value.latestRelease.spec;
-
-    if (!haloVersion.value || !requires) {
-      return false;
-    }
-
-    return semver.satisfies(haloVersion.value, requires, { includePrerelease: true });
+    return satisfiesRequires(haloVersion.value, requires);
   });
 
   return { hasUpdate, isSatisfies, matchedApp };

--- a/console/src/composables/use-theme-version.ts
+++ b/console/src/composables/use-theme-version.ts
@@ -7,6 +7,7 @@ import semver from "semver";
 import { useHaloVersion } from "./use-halo-version";
 import { STORE_APP_ID } from "@/constant";
 import { useFetchInstalledThemes } from "./use-theme";
+import { satisfiesRequires } from "@/utils/version";
 
 export function useThemeVersion(theme: Ref<Theme | undefined>) {
   const { haloVersion } = useHaloVersion();
@@ -62,12 +63,7 @@ export function useThemeVersion(theme: Ref<Theme | undefined>) {
       return false;
     }
     const { requires } = matchedApp.value.latestRelease.spec;
-
-    if (!haloVersion.value || !requires) {
-      return false;
-    }
-
-    return semver.satisfies(haloVersion.value, requires, { includePrerelease: true });
+    return satisfiesRequires(haloVersion.value, requires);
   });
 
   return { hasUpdate, isSatisfies, matchedApp };

--- a/console/src/utils/__tests__/version.spec.ts
+++ b/console/src/utils/__tests__/version.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { satisfiesRequires } from "../version";
+
+describe("satisfiesRequires", () => {
+  it("should return true when version satisfies required range", () => {
+    expect(satisfiesRequires("0.0.0", ">=2.2.0")).toBe(true);
+    expect(satisfiesRequires("2.0.0", "*")).toBe(true);
+    expect(satisfiesRequires("2.0.0", "")).toBe(true);
+    expect(satisfiesRequires("2.0.0", ">=2.0.0")).toBe(true);
+    expect(satisfiesRequires("2.1.0", "2.0.0")).toBe(true);
+  });
+
+  it("should return false when version does not satisfy required range", () => {
+    expect(satisfiesRequires("2.0.0", ">2.0.0")).toBe(false);
+    expect(satisfiesRequires("2.0.0", ">=2.1.0")).toBe(false);
+  });
+
+  it("should return true when version or required range is missing", () => {
+    expect(satisfiesRequires("2.0.0", undefined)).toBe(true);
+    expect(satisfiesRequires(undefined, undefined)).toBe(true);
+    expect(satisfiesRequires(undefined, ">=2.0.0")).toBe(true);
+  });
+
+  it("should return true when version satisfies required range with prerelease", () => {
+    expect(satisfiesRequires("2.0.0-beta.1", ">=2.0.0-beta.1")).toBe(true);
+    expect(satisfiesRequires("2.0.0-beta.1", ">=2.0.0-beta.0")).toBe(true);
+    expect(satisfiesRequires("2.0.0-beta.1", ">=2.0.0-alpha.0")).toBe(true);
+    expect(satisfiesRequires("2.0.0", ">=2.0.0-alpha.0")).toBe(true);
+  });
+});

--- a/console/src/utils/__tests__/version.spec.ts
+++ b/console/src/utils/__tests__/version.spec.ts
@@ -3,7 +3,6 @@ import { satisfiesRequires } from "../version";
 
 describe("satisfiesRequires", () => {
   it("should return true when version satisfies required range", () => {
-    expect(satisfiesRequires("0.0.0", ">=2.2.0")).toBe(true);
     expect(satisfiesRequires("2.0.0", "*")).toBe(true);
     expect(satisfiesRequires("2.0.0", "")).toBe(true);
     expect(satisfiesRequires("2.0.0", ">=2.0.0")).toBe(true);
@@ -11,6 +10,7 @@ describe("satisfiesRequires", () => {
   });
 
   it("should return false when version does not satisfy required range", () => {
+    expect(satisfiesRequires("0.0.0", ">=2.2.0")).toBe(false);
     expect(satisfiesRequires("2.0.0", ">2.0.0")).toBe(false);
     expect(satisfiesRequires("2.0.0", ">=2.1.0")).toBe(false);
   });
@@ -18,7 +18,6 @@ describe("satisfiesRequires", () => {
   it("should return true when version or required range is missing", () => {
     expect(satisfiesRequires("2.0.0", undefined)).toBe(true);
     expect(satisfiesRequires(undefined, undefined)).toBe(true);
-    expect(satisfiesRequires(undefined, ">=2.0.0")).toBe(true);
   });
 
   it("should return true when version satisfies required range with prerelease", () => {

--- a/console/src/utils/version.ts
+++ b/console/src/utils/version.ts
@@ -25,5 +25,5 @@ export function satisfiesRequires(version?: string, requires?: string): boolean 
     requires = `>=${requires}`;
   }
 
-  return version === "0.0.0" || semver.satisfies(version, requires, { includePrerelease: true });
+  return semver.satisfies(version, requires, { includePrerelease: true });
 }

--- a/console/src/utils/version.ts
+++ b/console/src/utils/version.ts
@@ -11,8 +11,12 @@ const VERSION_REGEX = /^\d+\.\d+\.\d+$/g;
  * @returns A boolean indicating whether the version satisfies the required range.
  */
 export function satisfiesRequires(version?: string, requires?: string): boolean {
-  if (!version || !requires) {
-    return false;
+  if (!version) {
+    version = "0.0.0";
+  }
+
+  if (!requires) {
+    return true;
   }
 
   requires = requires.trim();
@@ -21,5 +25,5 @@ export function satisfiesRequires(version?: string, requires?: string): boolean 
     requires = `>=${requires}`;
   }
 
-  return semver.satisfies(version, requires, { includePrerelease: true });
+  return version === "0.0.0" || semver.satisfies(version, requires, { includePrerelease: true });
 }

--- a/console/src/utils/version.ts
+++ b/console/src/utils/version.ts
@@ -1,0 +1,25 @@
+import semver from "semver";
+
+const VERSION_REGEX = /^\d+\.\d+\.\d+$/g;
+
+/**
+ * Checks if a given version satisfies a required version range.
+ *
+ * @see https://github.com/halo-dev/halo/blob/a5a69780a37410d2734043d6cae1b718b57c722b/application/src/main/java/run/halo/app/infra/utils/VersionUtils.java#L18
+ * @param version - The version to check.
+ * @param requires - The required version range.
+ * @returns A boolean indicating whether the version satisfies the required range.
+ */
+export function satisfiesRequires(version?: string, requires?: string): boolean {
+  if (!version || !requires) {
+    return false;
+  }
+
+  requires = requires.trim();
+
+  if (VERSION_REGEX.test(requires)) {
+    requires = `>=${requires}`;
+  }
+
+  return semver.satisfies(version, requires, { includePrerelease: true });
+}


### PR DESCRIPTION
基于 semver 封装新的版本范围检查方法，兼容 [Halo 的规则](https://github.com/halo-dev/halo/blob/a5a69780a37410d2734043d6cae1b718b57c722b/application/src/main/java/run/halo/app/infra/utils/VersionUtils.java#L18)。

Fixes #38 

<img width="1216" alt="image" src="https://github.com/halo-dev/plugin-app-store/assets/21301288/ac79588d-d6e5-42a0-9505-22d53431267f">

/kind improvement

```release-note
修复部分应用因为版本范围规则检测方法导致不兼容的问题。
```

