### PR TITLE
fix: app store binding lost after theme upgraded 

### DIFF
--- a/console/src/composables/use-app-download.ts
+++ b/console/src/composables/use-app-download.ts
@@ -173,6 +173,7 @@ export function useAppDownload(app: Ref<ApplicationSearchResult | undefined>) {
         });
 
         if (await checkPluginUpgradeStatus(matchedPlugin.value, app.value?.latestRelease?.spec.version)) {
+          await handleBindingPluginAppId({ plugin: upgradedPlugin });
           return upgradedPlugin;
         }
         return;
@@ -190,6 +191,7 @@ export function useAppDownload(app: Ref<ApplicationSearchResult | undefined>) {
         });
 
         if (await checkThemeUpgradeStatus(matchedTheme.value, app.value?.latestRelease?.spec.version)) {
+          await handleBindingThemeAppId({ theme: upgradedTheme });
           return upgradedTheme;
         }
         return;


### PR DESCRIPTION
修复主题升级之后与应用市场绑定丢失的问题。

/kind bug

Fixes #41 

```release-note
修复主题升级之后与应用市场绑定丢失的问题。
```