### PR TITLE
refactor: update pat address of halo official site

### DIFF
--- a/console/src/components/plugin-tabs/AccountBindingTab.vue
+++ b/console/src/components/plugin-tabs/AccountBindingTab.vue
@@ -68,7 +68,7 @@ const { mutate, isLoading } = useMutation({
   },
 });
 
-const haloPatAddress = `${import.meta.env.VITE_APP_STORE_BACKEND}/console/users/-/?tab=pat`;
+const haloPatAddress = `${import.meta.env.VITE_APP_STORE_BACKEND}/uc/profile?tab=pat`;
 </script>
 
 <template>


### PR DESCRIPTION
Halo 官网即将升级到 2.11.0，所以需要修改设置 PAT 的地址。

此外，在一段时间内，`/console/users/-/?tab=pat` 将重定向到 `/uc/profile?tab=pat`

```release-note
更新设置中，Halo 官网设置 PAT 的地址。
```